### PR TITLE
Fix issue when passing single Native Object as param to a component

### DIFF
--- a/lib/react/rendering_context.rb
+++ b/lib/react/rendering_context.rb
@@ -65,7 +65,10 @@ module React
 
       def remove_nodes_from_args(args)
         args[0].each do |key, value|
-          value.as_node if value.is_a?(Element) rescue nil
+          begin
+            value.as_node if value.is_a?(Element)
+          rescue Exception
+          end
         end if args[0] && args[0].is_a?(Hash)
       end
 


### PR DESCRIPTION
Followup from gitter chat.
Patch is a result of the debugging `react-bootstrap-table` to work as 3rd party component in a rails app.

kudos to @catmando 