### PR TITLE
Fix Fixnum Bignum deprecation warning

### DIFF
--- a/lib/reactive-ruby/serializers.rb
+++ b/lib/reactive-ruby/serializers.rb
@@ -1,7 +1,13 @@
-[Bignum, FalseClass, Fixnum, Float, Integer, NilClass, String, Symbol, Time, TrueClass].each do |klass|
-  klass.send(:define_method, :react_serializer) do 
-    as_json
-  end
+[TrueClass, FalseClass, NilClass, Float, String, Symbol, Time].each do |klass|
+  klass.send(:define_method, :react_serializer) { as_json }
+end
+# Ruby 2.4 unifies Fixnum and Bignum into Integer
+# and prints a warning if the old constants are accessed.
+if 0.class == Integer
+  Integer.send(:define_method, :react_serializer) { as_json }
+else
+  Fixnum.send(:define_method, :react_serializer) { as_json }
+  Bignum.send(:define_method, :react_serializer) { as_json }
 end
 
 BigDecimal.send(:define_method, :react_serializer) { as_json } rescue nil


### PR DESCRIPTION
Ruby 2.4 unifies Fixnum and Bignum into Integer and prints a warning if the old constants are accessed. hyper-react causes this warning to be printed on boot: 

```
lib/reactive-ruby/serializers.rb:1: warning: constant ::Bignum is deprecated
lib/reactive-ruby/serializers.rb:1: warning: constant ::Fixnum is deprecated
```

I've fixed this in the [same way as Rails](https://github.com/jeremy/rails/blob/b9bda7fd891147a0bc0cffa6dd9d15601be8b472/activesupport/lib/active_support/core_ext/numeric/conversions.rb#L131) to support both older and newer versions of Ruby.